### PR TITLE
Fix: Profile setup flow, refresh token persistence, and profile page

### DIFF
--- a/frontend/src/components/PrivateRoute.jsx
+++ b/frontend/src/components/PrivateRoute.jsx
@@ -1,7 +1,27 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from "../contexts/AuthContext";
 
 export default function PrivateRoute({ children }) {
-  const { currentUser } = useAuth();
-  return currentUser ? children : <Navigate to="/login" />;
+  const { currentUser, isLoading, isAuthenticated } = useAuth();
+  const location = useLocation();
+
+  if (isLoading) {
+    // Optional: Render a loading spinner or a minimal loading message
+    return <div>Loading...</div>;
+  }
+
+  if (!isAuthenticated) {
+    // User is not authenticated, redirect to login page
+    // Pass the current location so we can redirect back after login (optional)
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  // User is authenticated, now check for profile completion
+  if (currentUser && currentUser.profile_complete === false && location.pathname !== '/profile-setup') {
+    // User is authenticated, profile is not complete, and they are not trying to access profile-setup
+    return <Navigate to="/profile-setup" state={{ from: location }} replace />;
+  }
+
+  // User is authenticated and profile is complete (or they are on /profile-setup)
+  return children;
 }

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -129,8 +129,8 @@ const Profile = () => {
   const fetchProfile = async () => {
     try {
       setLoading(true);
-      // Use the current user's ID from auth context
-      const profileData = await profileAPI.getProfile(currentUser.id);
+      // Fetches the authenticated user's profile (userId is not needed)
+      const profileData = await profileAPI.getProfile();
       setProfile(profileData);
     } catch (err) {
       console.error('Error fetching profile:', err);

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -78,9 +78,9 @@ export const authAPI = {
 
 // Profile API
 export const profileAPI = {
-  // Get user profile
-  getProfile: async (userId) => {
-    const response = await api.get(`/profiles/${userId}`);
+  // Get user profile (fetches the authenticated user's profile)
+  getProfile: async () => {
+    const response = await api.get('/profiles/'); // Removed ${userId}
     return response.data;
   },
   


### PR DESCRIPTION
This commit addresses several issues related to user authentication and profile management:

1.  **Profile Setup Flow**:
    - Modified the `isAuthenticated` middleware (backend) to restrict access for users with incomplete profiles. They are now only allowed to access authentication and profile-related endpoints. Other requests will result in a 403 error, prompting profile setup.
    - Updated `PrivateRoute.jsx` (frontend) to redirect users with incomplete profiles to the `/profile-setup` page, ensuring they complete their profile before accessing other protected areas.
    - Ensured the login process provides the necessary `profile_complete` flag for the frontend to handle initial redirection to profile setup.

2.  **Refresh Token Persistence ("Refresh Logs Out" Fix)**:
    - Corrected the `maxAge` calculation for the `refreshToken` cookie in `authController.js` (backend). The duration strings (e.g., '7d', '1h') are now correctly parsed into milliseconds, ensuring the cookie persists for the intended duration. This resolves an issue where refresh tokens might expire prematurely, causing you to be logged out on page refresh.

3.  **"My Profile" Page Functionality**:
    - Updated `profileAPI.getProfile` in the frontend service to call the correct backend endpoint (`GET /api/profiles/`) for fetching your profile data.
    - Confirmed that the backend provides an endpoint (`GET /api/profiles/picture/:filename`) for serving profile pictures, which is used by the "My Profile" page.

These changes improve the robustness of the authentication flow, ensure you complete your profile as required, and enhance the overall user experience by fixing premature logouts and ensuring profile data loads correctly.